### PR TITLE
Fix to place user-facing scripts in the top-level `bin/`

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -92,9 +92,9 @@ finish Installing Spark
 notice Configuring Spark
 rm -rf $build_dir/spark-home/lib/spark-examples-*
 rm -rf $build_dir/spark-home/yarn
-cautious_build_overlay conf/spark-env.sh            spark-home/
-cautious_build_overlay conf/log4j.properties.erb    spark-home/
-cautious_build_overlay conf/spark-defaults.conf.erb spark-home/
+cautious_build_overlay conf/spark-env.sh spark-home/
+cautious_build_overlay conf/log4j.properties.erb
+cautious_build_overlay conf/spark-defaults.conf.erb
 finish Configuring Spark
 
 start Installing s3n:// and s3a:// HDFS Support

--- a/bin/compile
+++ b/bin/compile
@@ -62,16 +62,19 @@ fetch_spark_tarball() {
 
 # Copy a file from the buildpack to the same relative location in the
 # build directory, unless it already exists.
+# Optional second arg is the namespace/prefix to contain the target within the base.
 cautious_build_overlay() {
   local target=$1
+  local dest_namespace="${2-}"
   local source_base=$bp_dir
-  local dest_base=$build_dir/spark-home
-  if [ -f "${dest_base}/${target}" ]
+  local dest_base=$build_dir
+  if [ -f "${dest_base}/${dest_namespace}${target}" ]
   then
     echo "-----> Skipping copy, already exists in build: ${target}"
   else
     echo "-----> Copying into build: ${target}"
-    cp "${source_base}/${target}" "${dest_base}/${target}"
+    mkdir -p "${dest_base}/${dest_namespace}"
+    cp "${source_base}/${target}" "${dest_base}/${dest_namespace}${target}"
   fi
 }
 
@@ -89,9 +92,9 @@ finish Installing Spark
 notice Configuring Spark
 rm -rf $build_dir/spark-home/lib/spark-examples-*
 rm -rf $build_dir/spark-home/yarn
-cautious_build_overlay conf/spark-env.sh
-cautious_build_overlay conf/log4j.properties.erb
-cautious_build_overlay conf/spark-defaults.conf.erb
+cautious_build_overlay conf/spark-env.sh            spark-home/
+cautious_build_overlay conf/log4j.properties.erb    spark-home/
+cautious_build_overlay conf/spark-defaults.conf.erb spark-home/
 finish Configuring Spark
 
 start Installing s3n:// and s3a:// HDFS Support


### PR DESCRIPTION
Here's a "refinement" to the cautious overlay behavior, so that a target namespace/prefix can be specified for each overlay individually.

I'm having trouble testing it, because when I use the spark-in-space buildpack on a branch, the jumbo buildpack behavior is lost and the slug is too big.

@scott will you give it a thorough 🤓 logical look to make sure it's sane?