### PR TITLE
Default number of Spark cores = 4

### DIFF
--- a/conf/spark-defaults.conf.erb
+++ b/conf/spark-defaults.conf.erb
@@ -1,5 +1,6 @@
 spark.executor.memory=<%= ENV["SPARK_EXECUTOR_MEMORY"] || '12g' %>
 spark.driver.memory=<%= ENV["SPARK_DRIVER_MEMORY"] || '2g' %>
+spark.deploy.defaultCores=<%= ENV["SPARK_DEFAULT_CORES"] || '4' %>
 spark.executor.extraClassPath=/app/spark-home/lib/hadoop-aws-shaded.jar:/app/spark-home/lib/hadoop-lzo.jar
 spark.driver.extraClassPath=/app/spark-home/lib/hadoop-aws-shaded.jar:/app/spark-home/lib/hadoop-lzo.jar
 spark.hadoop.fs.s3a.impl=org.apache.hadoop.fs.s3a.S3AFileSystem

--- a/readme.md
+++ b/readme.md
@@ -56,10 +56,19 @@ to add more worker nodes to your spark cluster, simply scale the worker processe
 heroku scale worker=5 -a $app
 ```
 
+to make use of more worker nodes by default, set the config var:
+
+* `SPARK_DEFAULT_CORES`: default **4**; see [Resource Scheduling](http://spark.apache.org/docs/1.6.1/spark-standalone.html#resource-scheduling)
+
 to change the memory allocated to Spark, set the config vars:
 
 * `SPARK_EXECUTOR_MEMORY`: default **12g**; see [Application Properties](https://spark.apache.org/docs/1.6.1/configuration.html#application-properties)
 * `SPARK_DRIVER_MEMORY`: default **2g**; see [Application Properties](https://spark.apache.org/docs/1.6.1/configuration.html#application-properties)
+
+individual jobs may be tuned for memory & core utilization with [`spark-submit` options](http://spark.apache.org/docs/1.6.1/submitting-applications.html#launching-applications-with-spark-submit), examples:
+
+* `--executor-memory 4G`
+* `--total-executor-cores 16`
 
 ### viewing spark ui
 
@@ -136,6 +145,6 @@ This repo, when used as a buildpack, can support:
 
 * Spark 1.4.1 for Hadoop 2.6
 * Spark 1.6.1 for Hadoop 2.6 (default)
-* Spark 2.0.0 for hadoop 2.7
+* Spark 2.0.0 for Hadoop 2.7
 
 To use a specific version, place a file named `.spark.version` in the root of your project, containing the Spark version number, e.g. `1.4.1` or `2.0.0`.


### PR DESCRIPTION
Make it easy to running multiple concurrent jobs by default.

Readme updated to explain this new `SPARK_DEFAULT_CORES` config var, and how to change it for individual jobs.