### PR TITLE
Add support for Spark 2.1.0 reverse proxy config

### DIFF
--- a/conf/spark-defaults.conf.erb
+++ b/conf/spark-defaults.conf.erb
@@ -10,6 +10,10 @@ spark.hadoop.fs.s3n.multipart.uploads.block.size=536870912
 spark.hadoop.io.compression.codecs=org.apache.hadoop.io.compress.GzipCodec,org.apache.hadoop.io.compress.DefaultCodec,org.apache.hadoop.io.compress.BZip2Codec,com.hadoop.compression.lzo.LzoCodec,com.hadoop.compression.lzo.LzopCodec
 spark.hadoop.io.compression.codec.lzo.class=com.hadoop.compression.lzo.LzoCodec
 
+<% if ENV["SPARK_REVERSE_PROXY_URL"] %>
+spark.ui.reverseProxy=true
+spark.ui.reverseProxyUrl=<%= ENV["SPARK_REVERSE_PROXY_URL"] %>
+<% end %>
 
 <% if ENV["SPARK_S3_AWS_ACCESS_KEY_ID"] && ENV["SPARK_S3_AWS_SECRET_ACCESS_KEY"] %>
 spark.hadoop.fs.s3a.awsAccessKeyId=<%= ENV["SPARK_S3_AWS_ACCESS_KEY_ID"] %>

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,17 @@ individual jobs may be tuned for memory & core utilization with [`spark-submit` 
 
 ### viewing spark ui
 
-there is an nginx server that can proxy to any dyno in the space. The server will default you to proxying to the master.1 spark process.
+There is an nginx server that can proxy to any dyno in the space. The server will default you to proxying to the master.1 spark process.
+
+[As of Spark 2.1.0](https://issues.apache.org/jira/browse/SPARK-15487), a new configuration supports improved UI functionality when served through a this kind of reverse proxy. To enable the reverse proxy behavior, set the fully-qualified hostname that clients use to access Spark Master UI:
+
+```bash
+# Point to your custom domain/SSL endpoint for the Spark in Space deployment:
+heroku config:set SPARK_REVERSE_PROXY_URL=https://spark-in-space.example.com
+
+# …or if you're using the plain HTTP Space app URLs:
+heroku config:set SPARK_REVERSE_PROXY_URL=http://<your-spark-app>.herokuapp.com
+```
 
 To set a cookie so that you proxy to the spark master, hit the following url
 


### PR DESCRIPTION
We have this working with a Spark in Space cluster. While it *improves* the reverse proxy behavior, it does not completely *fix* it 😕